### PR TITLE
Added XSolidModelType.IfcSectionedSolidHorizontal

### DIFF
--- a/Xbim.Geometry.Abstractions/Enums/XSolidModelType.cs
+++ b/Xbim.Geometry.Abstractions/Enums/XSolidModelType.cs
@@ -17,6 +17,7 @@
         IfcFixedReferenceSweptAreaSolid,
         IfcRevolvedAreaSolid,
         IfcRevolvedAreaSolidTapered,
-        IfcSurfaceCurveSweptAreaSolid
+        IfcSectionedSolidHorizontal, // new in IFC4x1 Release Candidate 3
+		IfcSurfaceCurveSweptAreaSolid, 
     }
 }


### PR DESCRIPTION
The IfcSectionedSolidHorizontal solid model type (new in IFC4x1 and still in use in IFC4x3) has been added to the relevant enum.